### PR TITLE
NixOS module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,46 +17,11 @@
         "aarch64-darwin"
       ];
 
-      perSystem = { system, config, lib, pkgs, ... }: {
-        packages = {
-          shadowHarvester = let
-            naersk-lib = inputs.naersk.lib.${system};
-          in naersk-lib.buildPackage {
-            pname = "shadow-harvester";
-            version = "0.1.0";
-
-            src = with lib.fileset; toSource {
-              root = ./.;
-              fileset = unions [
-                ./Cargo.lock
-                ./Cargo.toml
-                ./src
-                ./tests
-              ];
-            };
-
-            buildInputs = with pkgs; [
-              pkg-config
-              openssl
-              zlib
-            ];
-          };
-
-          default = config.packages.shadowHarvester;
-        };
-
-        devShells.default = with pkgs; mkShell {
-          packages = [
-            cargo
-            rustc
-            pkg-config
-            openssl
-            zlib
-            rust-analyzer
-            rustfmt
-            clippy
-          ];
-        };
-      };
+      imports = [
+        nix/packages.nix
+        nix/devShells.nix
+        nix/nixosModules.nix
+        nix/overlays.nix
+      ];
     };
 }

--- a/nix/devShells.nix
+++ b/nix/devShells.nix
@@ -1,0 +1,16 @@
+{
+  perSystem = { pkgs, ... }: {
+    devShells.default = with pkgs; mkShell {
+      packages = [
+        cargo
+        rustc
+        pkg-config
+        openssl
+        zlib
+        rust-analyzer
+        rustfmt
+        clippy
+      ];
+    };
+  };
+}

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -1,0 +1,63 @@
+{
+  flake = { config, ... }: {
+    nixosModules = let
+      name = "shadow-harvester";
+    in {
+      default = {
+        imports = [
+          config.nixosModules.${name}
+        ];
+
+        nixpkgs.overlays = [
+          config.overlays.default
+        ];
+      };
+
+      ${name} = { config, lib, pkgs, ... }: let
+        cfg = config.services.${name};
+      in {
+        options.services.${name} = {
+          enable = lib.mkEnableOption name;
+
+          package = lib.mkPackageOption pkgs name {};
+
+          settings = lib.mkOption {
+            type = lib.types.submodule {
+              freeformType = with lib.types; attrsOf (oneOf [
+                str bool ints.u32
+              ]);
+
+              options.api-url = lib.mkOption {
+                type = lib.types.str;
+                default = "https://sm.midnight.gd/api";
+              };
+            };
+            default = {};
+          };
+        };
+
+        config = lib.mkIf cfg.enable {
+          systemd.services.${name} = {
+            after = ["network.target"];
+            wantedBy = ["multi-user.target"];
+
+            path = [cfg.package];
+
+            script = toString [
+              "exec"
+              (with lib; pipe cfg.package [getExe builtins.baseNameOf escapeShellArg])
+              (lib.cli.toGNUCommandLineShell {} cfg.settings)
+            ];
+
+            enableStrictShellChecks = true;
+
+            serviceConfig = {
+              Type = "exec";
+              DynamicUser = true;
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,5 @@
+{ getSystem, ... }: {
+  flake.overlays.default = _: prev: {
+    inherit ((getSystem prev.system).packages) shadow-harvester;
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,42 @@
+{ inputs, ... }: {
+  perSystem = { system, config, lib, pkgs, ... }: {
+    packages = {
+      shadow-harvester = let
+        naersk-lib = inputs.naersk.lib.${system};
+      in naersk-lib.buildPackage rec {
+        pname = "shadow-harvester";
+        version = "0.1.0";
+
+        src = with lib.fileset; toSource {
+          root = ./..;
+          fileset = unions [
+            ../Cargo.lock
+            ../Cargo.toml
+            ../src
+            ../tests
+          ];
+        };
+
+        buildInputs = with pkgs; [
+          pkg-config
+          openssl
+          zlib
+        ];
+
+        meta = {
+          mainProgram = pname;
+          maintainers = with lib.maintainers; [
+            disassembler
+            dermetfan
+          ];
+          license = with lib.licenses; [
+            asl20
+            mit
+          ];
+        };
+      };
+
+      default = config.packages.shadow-harvester;
+    };
+  };
+}


### PR DESCRIPTION
- add NixOS module
- add nixpkgs overlay
- add meta info to nix package
- filter sources to avoid spurious rebuilds

Usage:

```nix
imports [
  inputs.shadow-harvester.nixosModules.default
  # inputs.shadow-harvester.nixosModules.shadow-harvester # same as the default module but doesn't pull in the package
];

services.shadow-harvester = {
  enable = true;
  settings = {
    accept-tos = true;
    donate-to = "addr…";
  };
};
```