### PR TITLE
Feature: Asynchronous Solution Submission Queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "shadow-harvester" # 🚨 NEW: The project and library name
+name = "shadow-harvester"
 version = "0.1.0"
 edition = "2024"
 license = "MIT Or Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -22,7 +22,6 @@ pub fn fetch_tandc(client: &blocking::Client, api_url: &str) -> Result<TandCResp
     response.json()
 }
 
-// NEW FUNCTION: Parses the comma-separated CLI challenge string
 pub fn parse_cli_challenge_string(challenge_str: &str) -> Result<CliChallengeData, String> {
     let parts: Vec<&str> = challenge_str.split(',').collect();
 
@@ -44,7 +43,6 @@ pub fn parse_cli_challenge_string(challenge_str: &str) -> Result<CliChallengeDat
 
 
 /// Performs the POST /register call using key/signature arguments.
-// RENAMED from register_address_mock
 pub fn register_address(
     client: &blocking::Client,
     api_url: &str,
@@ -139,7 +137,6 @@ pub fn submit_solution(
 }
 
 /// Performs the POST /donate_to call.
-// RENAMED from donate_to_mock
 pub fn donate_to(
     client: &blocking::Client,
     api_url: &str,
@@ -187,7 +184,6 @@ pub fn donate_to(
 }
 
 /// Fetches the raw Challenge Response object from the API.
-// NEW FUNCTION
 pub fn fetch_challenge_status(client: &blocking::Client, api_url: &str) -> Result<ChallengeResponse, String> {
     let url = format!("{}/challenge", api_url);
 
@@ -202,7 +198,6 @@ pub fn fetch_challenge_status(client: &blocking::Client, api_url: &str) -> Resul
 }
 
 /// Fetches and validates the active challenge parameters, returning data only if active.
-// RENAMED from fetch_challenge
 pub fn get_active_challenge_data(client: &blocking::Client, api_url: &str) -> Result<ChallengeData, String> {
     let challenge_response = fetch_challenge_status(client, api_url)?;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Cli {
     #[arg(long)]
     pub payment_key: Option<String>,
 
-    /// NEW: Automatically generate a new ephemeral key pair for every mining cycle.
+    /// Automatically generate a new ephemeral key pair for every mining cycle.
     #[arg(long)]
     pub ephemeral_key: bool,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -587,8 +587,6 @@ pub fn scavenge(
             // Set start_nonce = thread_id
             let start_nonce = thread_id;
 
-            println!("Starting thread {} with initial nonce: {:016x} and step size: {}", thread_id, start_nonce, step_size);
-
             s.spawn(move || {
                 spin(params, sender, stop_signal, start_nonce, step_size)
             });

--- a/src/mining.rs
+++ b/src/mining.rs
@@ -1,22 +1,58 @@
 // src/mining.rs
 
 use crate::api;
-use crate::data_types::{DataDir, DataDirMnemonic, MiningContext, MiningResult, ChallengeData}; // Added ChallengeData
+use crate::data_types::{DataDir, DataDirMnemonic, MiningContext, MiningResult, ChallengeData, PendingSolution, FILE_NAME_FOUND_SOLUTION, is_solution_pending_in_queue, FILE_NAME_RECEIPT};
 use crate::cli::Cli;
 use crate::cardano;
 use crate::utils::{self, next_wallet_deriv_index_for_challenge, print_mining_setup, print_statistics, receipt_exists_for_index, run_single_mining_cycle};
+use std::{fs, path::PathBuf}; // Added fs, path::PathBuf
 
+// ===============================================
+// SOLUTION RECOVERY FUNCTION
+// ===============================================
+
+/// Checks the local storage for any solution that was found but not yet queued
+/// and queues it if found.
+fn check_for_unsubmitted_solutions(base_dir: &str, challenge_id: &str, mining_address: &str, data_dir_variant: &DataDir) -> Result<(), String> {
+    // Determine the base path for the specific wallet/challenge
+    let mut path = data_dir_variant.receipt_dir(base_dir, challenge_id)?;
+    path.push(FILE_NAME_FOUND_SOLUTION);
+
+    if path.exists() {
+        println!("\n⚠️ Recovery file detected at {:?}. Recovering solution...", path);
+
+        let solution_json = fs::read_to_string(&path)
+            .map_err(|e| format!("Failed to read recovery file {:?}: {}", path, e))?;
+
+        let pending_solution: PendingSolution = serde_json::from_str(&solution_json)
+            .map_err(|e| format!("Failed to parse recovery solution JSON {:?}: {}", path, e))?;
+
+        // 1. Save to the main submission queue
+        if let Err(e) = data_dir_variant.save_pending_solution(base_dir, &pending_solution) {
+            return Err(format!("FATAL RECOVERY ERROR: Could not queue recovered solution: {}", e));
+        }
+
+        // 2. Delete the recovery file
+        if let Err(e) = fs::remove_file(&path) {
+            eprintln!("WARNING: Successfully queued recovered solution but FAILED TO DELETE RECOVERY FILE {:?}: {}", path, e);
+        } else {
+            println!("✅ Successfully recovered and queued solution for address {} / challenge {}.", mining_address, challenge_id);
+        }
+    }
+    Ok(())
+}
 
 // ===============================================
 // MINING MODE FUNCTIONS (Core Logic Only)
 // ===============================================
 
 /// MODE A: Persistent Key Continuous Mining
+#[allow(unused_assignments)] // Suppress warnings for final_hashes/final_elapsed assignments
 pub fn run_persistent_key_mining(context: MiningContext, skey_hex: &String) -> Result<(), String> {
     let key_pair = cardano::generate_cardano_key_pair_from_skey(skey_hex);
     let mining_address = key_pair.2.to_bech32().unwrap();
-    let mut final_hashes: u64;
-    let mut final_elapsed: f64;
+    let mut final_hashes: u64 = 0;
+    let mut final_elapsed: f64 = 0.0;
     let reg_message = context.tc_response.message.clone();
     let data_dir = DataDir::Persistent(&mining_address);
 
@@ -35,24 +71,22 @@ pub fn run_persistent_key_mining(context: MiningContext, skey_hex: &String) -> R
     if context.donate_to_option.is_some() { println!("Donation Target: {}", context.donate_to_option.unwrap()); }
 
     let mut current_challenge_id = String::new();
-    let mut last_active_challenge_data: Option<ChallengeData> = None; // ADDED: Store last valid challenge data
+    let mut last_active_challenge_data: Option<ChallengeData> = None;
     loop {
-        let challenge_params: ChallengeData = match utils::get_challenge_params(&context.client, &context.api_url, context.cli_challenge, &mut current_challenge_id) {
+        let challenge_params = match utils::get_challenge_params(&context.client, &context.api_url, context.cli_challenge, &mut current_challenge_id) {
             Ok(Some(params)) => {
-                last_active_challenge_data = Some(params.clone()); // Store on success
+                last_active_challenge_data = Some(params.clone());
                 params
             },
             Ok(None) => continue,
             Err(e) => {
-                // NEW LOGIC: If a challenge ID is set AND we detect a network failure, continue mining.
+                // If a challenge ID is set AND we detect a network failure, continue mining.
                 if !current_challenge_id.is_empty() && e.contains("API request failed") {
                     eprintln!("⚠️ Challenge API poll failed (Network Error): {}. Continuing mining with previous challenge parameters (ID: {})...", e, current_challenge_id);
-                    // Use the last stored parameters, which must exist if current_challenge_id is set.
                     last_active_challenge_data.as_ref().cloned().ok_or_else(|| {
                         format!("FATAL LOGIC ERROR: Challenge ID {} is set but no previous challenge data was stored.", current_challenge_id)
                     })?
                 } else {
-                    // Otherwise, it's a critical error (non-network failure or no challenge active), so wait and retry poll.
                     eprintln!("⚠️ Critical API Error during challenge check: {}. Retrying in 1 minute...", e);
                     std::thread::sleep(std::time::Duration::from_secs(60));
                     continue;
@@ -60,28 +94,29 @@ pub fn run_persistent_key_mining(context: MiningContext, skey_hex: &String) -> R
             }
         };
 
+        // Check for unsubmitted solutions from previous run
+        if let Some(base_dir) = context.data_dir {
+            check_for_unsubmitted_solutions(base_dir, &challenge_params.challenge_id, &mining_address, &data_dir)?;
+        }
+
         if let Some(base_dir) = context.data_dir { data_dir.save_challenge(base_dir, &challenge_params)?; }
         print_mining_setup(&context.api_url, Some(mining_address.as_str()), context.threads, &challenge_params);
 
         loop {
+            // UPDATED CALL: Removed client and api_url
             let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
-                &context.client, &context.api_url, mining_address.clone(), context.threads, context.donate_to_option, &challenge_params, &key_pair,
+                mining_address.clone(), context.threads, context.donate_to_option, &challenge_params, context.data_dir,
             );
             final_hashes = total_hashes; final_elapsed = elapsed_secs;
 
             match result {
-                MiningResult::FoundAndSubmitted((ref receipt, ref donation)) => {
-                    println!("\n✅ Solution submitted. Stopping current mining.");
-                    if let Some(base_dir) = context.data_dir { data_dir.save_receipt(base_dir, &challenge_params.challenge_id, receipt, donation)?; }
-                    break;
+                MiningResult::FoundAndQueued => {
+                    println!("\n✅ Solution queued. Continuing mining immediately.");
+                    // Continue the loop on the same address.
                 },
                 MiningResult::AlreadySolved => {
-                    println!("\n✅ Challenge already solved on network. Writing placeholder receipt to skip on next run.");
-                    // Write a placeholder receipt on "AlreadySolved" API response
-                    let placeholder_receipt = serde_json::json!({"status": "already_solved_on_network"});
-                    if let Some(base_dir) = context.data_dir {
-                        data_dir.save_receipt(base_dir, &challenge_params.challenge_id, &placeholder_receipt, &None)?;
-                    }
+                    println!("\n✅ Challenge already solved on network. Stopping current mining.");
+                    // Solution saved by submitter/already exists, so check for a new challenge.
                     break;
                 }
                 MiningResult::MiningFailed => {
@@ -120,7 +155,7 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
     let mut backoff_reg = crate::backoff::Backoff::new(5, 300, 2.0);
     let mut last_seen_challenge_id = String::new();
     let mut current_challenge_id = String::new();
-    let mut last_active_challenge_data: Option<ChallengeData> = None; // ADDED: Store last valid challenge data
+    let mut last_active_challenge_data: Option<ChallengeData> = None;
 
     println!("\n==============================================");
     println!("⛏️  Shadow Harvester: MNEMONIC SEQUENTIAL MINING Mode ({})", if context.cli_challenge.is_some() { "FIXED CHALLENGE" } else { "DYNAMIC POLLING" });
@@ -136,18 +171,22 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
         let challenge_params: ChallengeData = match utils::get_challenge_params(&context.client, &context.api_url, context.cli_challenge, &mut current_challenge_id) {
             Ok(Some(params)) => {
                 backoff_challenge.reset();
-                last_active_challenge_data = Some(params.clone()); // Store on success
+                last_active_challenge_data = Some(params.clone());
                 if first_run || (context.cli_challenge.is_none() && params.challenge_id != old_challenge_id) {
                     // Create a dummy DataDir with index 0 to calculate the base path for scanning
                     let temp_data_dir = DataDir::Mnemonic(DataDirMnemonic { mnemonic: &mnemonic_phrase, account: cli.mnemonic_account, deriv_index: 0 });
-                    wallet_deriv_index = next_wallet_deriv_index_for_challenge(&cli.data_dir, &params.challenge_id, &temp_data_dir)?;
+
+                    let next_index_from_receipts = next_wallet_deriv_index_for_challenge(&cli.data_dir, &params.challenge_id, &temp_data_dir)?;
+
+                    // FIX: Take the maximum of the index derived from receipts and the CLI starting index.
+                    wallet_deriv_index = next_index_from_receipts.max(cli.mnemonic_starting_index);
                 }
                 last_seen_challenge_id = params.challenge_id.clone();
                 params
             },
             Ok(None) => { backoff_challenge.reset(); continue; },
             Err(e) => {
-                // NEW LOGIC: If a challenge ID is set AND we detect a network failure, continue mining.
+                // If a challenge ID is set AND we detect a network failure, continue mining.
                 if !current_challenge_id.is_empty() && e.contains("API request failed") {
                     eprintln!("⚠️ Challenge API poll failed (Network Error): {}. Continuing mining with previous challenge parameters (ID: {})...", e, current_challenge_id);
                     backoff_challenge.reset();
@@ -171,13 +210,49 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
         // This loop ensures we skip indices with existing receipts, even if the index hasn't changed.
         'skip_check: loop {
             let wallet_config = DataDirMnemonic { mnemonic: &mnemonic_phrase, account: cli.mnemonic_account, deriv_index: wallet_deriv_index };
+            let data_dir = DataDir::Mnemonic(wallet_config); // Full DataDir for recovery check
+
+            // Get the temporary mining address for this index (needed for queue file lookup/recovery)
+            let mining_address_temp = cardano::derive_key_pair_from_mnemonic(&mnemonic_phrase, cli.mnemonic_account, wallet_deriv_index).2.to_bech32().unwrap();
+
+            // Check for unsubmitted solutions (recovery file or pending queue)
             if let Some(base_dir) = context.data_dir {
+                if wallet_deriv_index >= cli.mnemonic_starting_index {
+                    // 1. Check for crash recovery file (found.json)
+                    check_for_unsubmitted_solutions(base_dir, &challenge_params.challenge_id, &mining_address_temp, &data_dir)?;
+
+                    // 2. Check if a solution for this address/challenge is already in the pending queue
+                    if is_solution_pending_in_queue(base_dir, &mining_address_temp, &challenge_params.challenge_id)? {
+                        println!("\nℹ️ Index {} has a pending submission in the queue. Skipping and checking next index.", wallet_deriv_index);
+                        wallet_deriv_index = wallet_deriv_index.wrapping_add(1);
+                        continue 'skip_check;
+                    }
+                }
+            }
+
+            // --- Final Receipt Check (Multi-Path Resumption) ---
+            if let Some(base_dir) = context.data_dir {
+                // 1. Check Correct Mnemonic Path (where it should be)
                 if receipt_exists_for_index(base_dir, &challenge_params.challenge_id, &wallet_config)? {
-                    println!("\nℹ️ Index {} already has a local receipt. Skipping and checking next index.", wallet_deriv_index);
+                    println!("\nℹ️ Index {} already has a local receipt (Mnemonic path). Skipping.", wallet_deriv_index);
+                    wallet_deriv_index = wallet_deriv_index.wrapping_add(1);
+                    continue 'skip_check;
+                }
+
+                // 2. Check INCORRECT Persistent Path (where submitter currently writes receipts due to heuristic)
+                let mut persistent_path = data_dir.challenge_dir(base_dir, &challenge_params.challenge_id)?;
+                persistent_path.push("persistent");
+                persistent_path.push(&mining_address_temp); // The address derived for this index
+                persistent_path.push(FILE_NAME_RECEIPT);
+
+                if persistent_path.exists() {
+                    println!("\n⚠️ Index {} found receipt in Persistent path (Submitter heuristic failure). Skipping.", wallet_deriv_index);
                     wallet_deriv_index = wallet_deriv_index.wrapping_add(1);
                     continue 'skip_check;
                 }
             }
+
+            // If none of the above conditions met, we break and mine.
             break 'skip_check;
         }
 
@@ -203,23 +278,19 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
 
         print_mining_setup(&context.api_url, Some(mining_address.as_str()), context.threads, &challenge_params);
 
+        // UPDATED CALL: Removed client and api_url
         let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
-            &context.client, &context.api_url, mining_address.clone(), context.threads, context.donate_to_option, &challenge_params, &key_pair,
+            mining_address.clone(), context.threads, context.donate_to_option, &challenge_params, context.data_dir,
         );
 
         // --- 4. Post-Mining Index Advancement ---
         match result {
-            MiningResult::FoundAndSubmitted((receipt, donation)) => {
-                if let Some(base_dir) = context.data_dir { data_dir.save_receipt(base_dir, &challenge_params.challenge_id, &receipt, &donation)?; }
+            MiningResult::FoundAndQueued => {
                 wallet_deriv_index = wallet_deriv_index.wrapping_add(1);
-                println!("\n✅ Solution submitted. Incrementing index to {}.", wallet_deriv_index);
+                println!("\n✅ Solution queued. Incrementing index to {}.", wallet_deriv_index);
             },
             MiningResult::AlreadySolved => {
-                // Write a placeholder receipt on "AlreadySolved" API response
-                let placeholder_receipt = serde_json::json!({"status": "already_solved_on_network"});
-                if let Some(base_dir) = context.data_dir {
-                    data_dir.save_receipt(base_dir, &challenge_params.challenge_id, &placeholder_receipt, &None)?;
-                }
+                // This scenario means the submitter/API reported it was already solved
                 wallet_deriv_index = wallet_deriv_index.wrapping_add(1);
                 println!("\n✅ Challenge already solved. Incrementing index to {}.", wallet_deriv_index);
             }
@@ -233,26 +304,27 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
 }
 
 /// MODE C: Ephemeral Key Per Cycle Mining
+#[allow(unused_assignments)] // Suppress warnings for final_hashes/final_elapsed assignments
 pub fn run_ephemeral_key_mining(context: MiningContext) -> Result<(), String> {
     println!("\n==============================================");
     println!("⛏️  Shadow Harvester: EPHEMERAL KEY MINING Mode ({})", if context.cli_challenge.is_some() { "FIXED CHALLENGE" } else { "DYNAMIC POLLING" });
     println!("==============================================");
     if context.donate_to_option.is_some() { println!("Donation Target: {}", context.donate_to_option.unwrap()); }
 
-    let mut final_hashes: u64;
-    let mut final_elapsed: f64;
+    let mut final_hashes: u64 = 0;
+    let mut final_elapsed: f64 = 0.0;
     let mut current_challenge_id = String::new();
-    let mut last_active_challenge_data: Option<ChallengeData> = None; // ADDED: Store last valid challenge data
+    let mut last_active_challenge_data: Option<ChallengeData> = None;
 
     loop {
         let challenge_params: ChallengeData = match utils::get_challenge_params(&context.client, &context.api_url, context.cli_challenge, &mut current_challenge_id) {
             Ok(Some(p)) => {
-                last_active_challenge_data = Some(p.clone()); // Store on success
+                last_active_challenge_data = Some(p.clone());
                 p
             },
             Ok(None) => continue,
             Err(e) => {
-                // NEW LOGIC: If a challenge ID is set AND we detect a network failure, continue mining.
+                // If a challenge ID is set AND we detect a network failure, continue mining.
                 if !current_challenge_id.is_empty() && e.contains("API request failed") {
                     eprintln!("⚠️ Challenge API poll failed (Network Error): {}. Continuing mining with previous challenge parameters (ID: {})...", e, current_challenge_id);
                     last_active_challenge_data.as_ref().cloned().ok_or_else(|| {
@@ -282,14 +354,15 @@ pub fn run_ephemeral_key_mining(context: MiningContext) -> Result<(), String> {
 
         print_mining_setup(&context.api_url, Some(&generated_mining_address.to_string()), context.threads, &challenge_params);
 
+        // UPDATED CALL: Removed client and api_url
         let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
-                &context.client, &context.api_url, generated_mining_address.to_string(), context.threads, context.donate_to_option, &challenge_params, &key_pair,
+                generated_mining_address.to_string(), context.threads, context.donate_to_option, &challenge_params, context.data_dir,
             );
         final_hashes = total_hashes; final_elapsed = elapsed_secs;
 
         match result {
-            MiningResult::FoundAndSubmitted((receipt, donation)) => {
-                if let Some(base_dir) = context.data_dir { data_dir.save_receipt(base_dir, &challenge_params.challenge_id, &receipt, &donation)?; }
+            MiningResult::FoundAndQueued => {
+                eprintln!("Solution queued. Starting next cycle immediately...");
             }
             MiningResult::AlreadySolved => { eprintln!("Solution was already accepted by the network. Starting next cycle immediately..."); }
             MiningResult::MiningFailed => { eprintln!("Mining cycle failed. Retrying next cycle in 1 minute..."); std::thread::sleep(std::time::Duration::from_secs(60)); }

--- a/src/submitter.rs
+++ b/src/submitter.rs
@@ -1,0 +1,130 @@
+// src/submitter.rs
+
+use crate::data_types::{PendingSolution, DataDir, ChallengeData};
+use crate::api;
+use crate::cardano::{self};
+use crate::backoff::Backoff;
+use reqwest::blocking::Client;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use std::{fs, thread};
+
+// CONSTANTS for the submitter loop
+const SUBMISSION_INTERVAL_SECS: u64 = 5;
+const QUEUE_BASE_DIR: &str = "pending_submissions";
+
+pub fn run_submitter_thread(client: Client, api_url: String, data_dir_base: String) -> Result<(), String> {
+    println!("📦 Starting background submission queue monitor.");
+    let queue_path = PathBuf::from(&data_dir_base).join(QUEUE_BASE_DIR);
+
+    if !queue_path.exists() {
+        if let Err(e) = fs::create_dir_all(&queue_path) {
+            return Err(format!("Failed to create submission queue directory: {}", e));
+        }
+    }
+
+    loop {
+        // --- 1. Scan for pending solution files ---
+        let mut processed_submission = false;
+        match fs::read_dir(&queue_path) {
+            Ok(entries) => {
+                for entry in entries.filter_map(|e| e.ok()) {
+                    let path = entry.path();
+                    if path.is_file() && path.extension().map_or(false, |ext| ext == "json") {
+                        // Attempt to process the file, break on success to immediately check the next one
+                        if process_pending_solution(&client, &api_url, &path, &data_dir_base).is_ok() {
+                            processed_submission = true;
+                            break;
+                        }
+                    }
+                }
+            },
+            Err(e) => eprintln!("Error reading submission queue directory: {}", e),
+        }
+
+        // --- 2. Sleep based on activity ---
+        if !processed_submission {
+            thread::sleep(Duration::from_secs(SUBMISSION_INTERVAL_SECS));
+        }
+    }
+}
+
+fn process_pending_solution(client: &Client, api_url: &str, file_path: &Path, data_dir_base: &str) -> Result<(), String> {
+    // --- 1. Load the pending solution ---
+    let solution_json = fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read pending solution file {:?}: {}", file_path, e))?;
+
+    let solution: PendingSolution = serde_json::from_str(&solution_json)
+        .map_err(|e| format!("Failed to parse pending solution JSON {:?}: {}", file_path, e))?;
+
+    println!("\n📦 Attempting to submit queued solution for Challenge ID {} (Nonce: {})...", solution.challenge_id, solution.nonce);
+
+    // --- 2. Submission Retry Loop (with Backoff) ---
+    let mut backoff = Backoff::new(5, 300, 2.0); // min 5s, max 300s, 2.0 factor
+    let mut final_receipt: Option<serde_json::Value> = None;
+    let mut submission_success = false;
+    let mut non_recoverable_error = false;
+
+    // Retry indefinitely on network errors, but break on API validation errors
+    loop {
+        match api::submit_solution(
+            client, api_url, &solution.address, &solution.challenge_id, &solution.nonce,
+        ) {
+            Ok(receipt) => {
+                final_receipt = Some(receipt);
+                submission_success = true;
+                break;
+            },
+            Err(e) if e.contains("Network/Client Error") => {
+                eprintln!("⚠️ Solution submission failed (Network Error): {}. Retrying...", e);
+                backoff.sleep();
+                continue;
+            },
+            Err(e) => {
+                // Non-recoverable API Error (Validation, Already Solved, Challenge Expired, etc.)
+                eprintln!("❌ Non-recoverable API Submission Error. Deleting from queue. Details: {}", e);
+                non_recoverable_error = true;
+                break;
+            }
+        }
+    }
+
+    if submission_success {
+        // Submission Success Confirmation
+        println!("🚀 Successfully submitted solution for Index {} (Challenge: {})", solution.address, solution.challenge_id);
+
+        // --- 3. Save Receipt and Clean Up ---
+        let receipt = final_receipt.unwrap();
+
+        // Determine the correct DataDir variant for saving the receipt
+        // Heuristic: differentiate Ephemeral from Persistent/Mnemonic based on address string.
+        let data_dir_instance = if solution.address.starts_with("addr_vk") {
+            DataDir::Ephemeral(&solution.address)
+        } else {
+            // Use Persistent as a default for address-based pathing (covers both Persistent and Mnemonic key modes' final address structure)
+            DataDir::Persistent(&solution.address)
+        };
+
+        // Call simplified save_receipt function (no donation ID)
+        if let Err(e) = data_dir_instance.save_receipt(data_dir_base, &solution.challenge_id, &receipt) {
+            eprintln!("FATAL: Successfully submitted but FAILED TO SAVE LOCAL RECEIPT: {}. The solution was accepted by the server. Delete the pending file manually to prevent re-submission.", e);
+            // Even though local save failed, the server has the solution. We must remove the pending file.
+        }
+
+        // Delete the pending solution file after successful API submission and (attempted) local receipt save
+        if let Err(e) = fs::remove_file(file_path) {
+            eprintln!("⚠️ WARNING: Successfully submitted solution but FAILED TO DELETE PENDING FILE {:?}: {}. This file may be resubmitted.", file_path, e);
+        }
+
+        Ok(())
+    } else if non_recoverable_error {
+        // Non-recoverable error, clean up the file
+         if let Err(e) = fs::remove_file(file_path) {
+            eprintln!("⚠️ WARNING: Received unrecoverable submission error but FAILED TO DELETE PENDING FILE {:?}: {}.", file_path, e);
+        }
+        Err(format!("Non-recoverable error processing {:?}", file_path))
+    } else {
+        // Should be unreachable if the loop logic is correct, but indicates a break without success/fatal error.
+        Err("Submission thread encountered unexpected state.".to_string())
+    }
+}


### PR DESCRIPTION
## 🚀 Feature: Asynchronous Solution Submission Queue

This PR introduces a significant architectural change by implementing a robust **Asynchronous Submission Queue**, effectively decoupling the high-speed hashing process from network I/O.

This resolves a critical vulnerability where temporary network errors (timeouts, client errors) or slow API responses could halt the entire mining operation, leading to downtime and inefficient resource usage.

### Key Architectural Changes

1.  **Producer-Consumer Decoupling:** The solution flow is converted to a classic **Producer-Consumer model**:
    * **Producer (Mining Threads):** Hashing logic runs non-stop, finding solutions quickly. The core hashing function (`run_single_mining_cycle`) is now **local-only**.
    * **Consumer (Submitter Thread):** A new **background thread** (`src/submitter.rs`) handles all external API communication at a safe, retriable pace.

2.  **Dedicated Submitter Thread (`src/submitter.rs`):**
    * The submitter runs continuously, monitoring the local `pending_submissions/` disk queue.
    * It is responsible for performing API calls (`/solution`), implementing backoff strategies on transient network failures, and confirming submission success before removing the item from the queue.
    * It also prints a clear **success confirmation** upon a successful API submission.

3.  **Local-Only Hashing Logic (`src/utils.rs`):**
    * The `run_single_mining_cycle` function has been stripped of all network responsibilities (`client`, `api_url` arguments removed).
    * Its sole action upon finding a nonce is a **three-stage atomic save process** to the local disk queue, ensuring **crash recovery** via the temporary `found.json` file.

4.  **Resilience and Efficiency:**
    * The miner's hashing core can continue running uninterrupted, maximizing efficiency.
    * **Fortified Mnemonic Resumption:** The Mnemonic mining loop (`src/mining.rs`) now correctly advances the index if a solution is found either in the **final receipt path** or the **live pending queue** (`/pending_submissions/`), preventing repeated mining of the same address.