### PR TITLE
Add concurrent multi-wallet mining feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,14 @@ pub struct Cli {
     /// Where to store state (like the mnemonic starting index) and receipts
     #[arg(long, default_value = ".")]
     pub data_dir: Option<String>,
+
+    /// Path to wallets.json file containing multiple wallets to mine with
+    #[arg(long)]
+    pub wallets_file: Option<String>,
+
+    /// Number of wallets to mine concurrently (only used with --wallets-file)
+    #[arg(long, default_value_t = 1)]
+    pub concurrent_wallets: usize,
 }
 
 

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -125,6 +125,33 @@ pub struct CliChallengeData {
 }
 
 // ===============================================
+// WALLET FILE STRUCTS
+// ===============================================
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct WalletEntry {
+    pub id: u32,
+    pub name: String,
+    pub mnemonic: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default)]
+    pub profile_dir: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub total_solved: u32,
+    #[serde(default)]
+    pub total_unsolved: u32,
+    #[serde(default)]
+    pub estimated_tokens: String,
+    #[serde(default)]
+    pub last_updated: String,
+}
+
+// ===============================================
 // CORE APPLICATION STRUCTS
 // ===============================================
 


### PR DESCRIPTION
- Add WalletEntry struct to parse wallets.json files
- Add CLI flags: --wallets-file and --concurrent-wallets
- Implement run_concurrent_wallets_mining function that:
  * Loads wallets from JSON file
  * Mines with N wallets concurrently
  * Rotates wallets as challenges are solved
  * Keeps mining with specified number of concurrent wallets
  * Automatically skips wallets that already solved the challenge
- Add wallet loader function in utils.rs
- Integrate new mining mode into main.rs
- Add validation to prevent conflicting flags

This allows users to maximize earning by mining with multiple wallets simultaneously, automatically rotating to new wallets as challenges are completed.

Usage:
  shadow-harvester --api-url <url> --accept-tos --wallets-file wallets.json --concurrent-wallets 5