### PR TITLE
Finish current challenge before starting the latest one

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -150,7 +150,6 @@ pub struct PendingSolution {
     pub address: String,
     pub challenge_id: String,
     pub nonce: String,
-    pub donation_address: Option<String>,
     // FIX: Add fields for error logging and identification
     pub preimage: String, // The full string used for hashing
     pub hash_output: String, // The final Blake2b hash output (hex encoded)

--- a/src/mining.rs
+++ b/src/mining.rs
@@ -125,7 +125,6 @@ pub fn run_persistent_key_mining(context: MiningContext, skey_hex: &String) -> R
             let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
                 mining_address.clone(),
                 context.threads,
-                context.donate_to_option.as_ref(), // Option<String> to Option<&String>
                 &challenge_params,
                 context.data_dir.as_deref(), // Option<String> to Option<&str>
             );
@@ -322,7 +321,6 @@ pub fn run_mnemonic_sequential_mining(cli: &Cli, context: MiningContext, mnemoni
         let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
             mining_address.clone(),
             context.threads,
-            context.donate_to_option.as_ref(), // Option<String> to Option<&String>
             &challenge_params,
             context.data_dir.as_deref(), // Option<String> to Option<&str>
         );
@@ -419,7 +417,6 @@ pub fn run_ephemeral_key_mining(context: MiningContext) -> Result<(), String> {
         let (result, total_hashes, elapsed_secs) = run_single_mining_cycle(
                 generated_mining_address.to_string(),
                 context.threads,
-                context.donate_to_option.as_ref(), // Option<String> to Option<&String>
                 &challenge_params,
                 context.data_dir.as_deref(), // Option<String> to Option<&str>
             );
@@ -558,7 +555,6 @@ pub fn spawn_miner_workers(
                         address: mining_address.clone(),
                         challenge_id: challenge_params.challenge_id.clone(),
                         nonce: nonce_hex,
-                        donation_address: None, // Donation address is handled by the Manager post-solution
                         preimage,
                         hash_output,
                     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -223,7 +223,6 @@ pub fn print_statistics(stats_result: Result<Statistics, String>, total_hashes: 
 pub fn run_single_mining_cycle(
     mining_address: String,
     threads: u32,
-    donate_to_option: Option<&String>,
     challenge_params: &ChallengeData,
     data_dir_base: Option<&str>,
 ) -> (MiningResult, u64, f64) {
@@ -250,7 +249,6 @@ pub fn run_single_mining_cycle(
                 address: mining_address.clone(),
                 challenge_id: challenge_params.challenge_id.clone(),
                 nonce: nonce.clone(),
-                donation_address: donate_to_option.cloned(),
                 // FIX: Add placeholder values for the new fields (synchronous function cannot capture full context)
                 preimage: "Legacy_Preimage_Not_Captured_Sync_Mode".to_string(),
                 hash_output: "Legacy_Hash_Not_Captured_Sync_Mode".to_string(),


### PR DESCRIPTION
Currently, when a new challenge is found, mining for the current one is stopped.
This is becoming a problem for lower hash rate miners as difficulty increases, since they might not be able to solve a challenge within one hour, so before a new one becomes available, and hence solving is always canceled before a solution could be found.

With this PR, the newest available challenge is started only after the previous one is solved.

---

To simplify the code, this also handles donation before starting a mining cycle. There is no point in delaying donation until after a solution was found — the API supports donation as long as the addresses are registered and the documentation even includes an example reply for that case.